### PR TITLE
Use https instead of auth requiring git for readonly submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "externals/tensorflow"]
 	path = externals/tensorflow
-	url = git@github.com:tensorflow/tensorflow.git
+	url = https://github.com/tensorflow/tensorflow.git
 	shallow = true
 [submodule "externals/JUCE"]
 	path = externals/JUCE
-	url = git@github.com:juce-framework/JUCE.git
+	url = https://github.com/juce-framework/JUCE.git
 	shallow = true


### PR DESCRIPTION
With the original state, the `repo-init.sh` can fail due to permissions.
This allows repo-init to work without additional setup.